### PR TITLE
fix: play css animation before sending alert

### DIFF
--- a/findtheace.js
+++ b/findtheace.js
@@ -9,17 +9,20 @@ cards.forEach(card => {
     if (card.classList.contains('flip')) return;
 
     card.classList.add('flip');
-
     if (card.dataset.card === 'ace') {
-      alert('Bravo, vous avez trouvé l\'As !');
-      continueBtn.style.display = 'inline-block'; 
-    } else {
-      alert('Désolé, vous êtes mort !');
-      
       setTimeout(() => {
-        cards.forEach(c => c.classList.remove('flip'));
-        shuffleCards();
-      }, 1000);
+        alert('Bravo, vous avez trouvé l\'As !');
+        continueBtn.style.display = 'inline-block';
+      }, 500);
+    } else {
+      setTimeout(() => {
+        alert('Désolé, vous êtes mort !');
+
+        setTimeout(() => {
+          cards.forEach(c => c.classList.remove('flip'));
+          shuffleCards();
+        }, 1000);
+      }, 500);
     }
   });
 });


### PR DESCRIPTION
### This fixes #2

---

**Issue Root Cause**

The problem was caused by the `alert()` function being threads **blocking**, which means it halts all other threads, including CSS transitions such as the card flip animation.

**Solution**

To solve this, we added a small delay (`setTimeout`) before triggering the alert. This gives the browser time to complete the flip animation before showing the message.

> [!IMPORTANT]  
> The 500ms delay is somewhat arbitrary.  
> According to [UX research](https://ux.stackexchange.com/questions/66604/optimal-duration-for-animating-transitions), animation durations between **100ms and 600ms** are considered ideal.  
> Feel free to tweak the delay and align it with the CSS animation duration for better scalability and consistency.

Hope you enjoy this PR! <3
