### PR TITLE
fix: update balance before spinning to wheel to avoid unexpected beha…

### DIFF
--- a/roulette.js
+++ b/roulette.js
@@ -22,6 +22,8 @@ function placeBet(type) {
     }
   }
 
+  balance -= betAmount;
+  updateBalance()
   spinRoulette(type, betAmount, chosenNumber);
 }
 


### PR DESCRIPTION
### This fixes #1

---

**Issue Root Cause**

The main issue was that the balance was only updated **after** the wheel spin.  
This caused a confusing behavior where the potential earnings were calculated based on the **pre-bet balance**, not the actual amount bet.

**Solution**

To fix this, the balance is now updated **immediately after placing the bet**.  
This ensures that the earnings (in case of a win) are based on the correct, post-bet balance.

Hope you enjoy this PR! <3